### PR TITLE
Use git repo in push destination

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,7 +75,7 @@ jobs:
               pushd $FOLDER
                 IMAGE_NAME=$(echo $FOLDER | sed -e "s,/,,g")
                 if [ -f Dockerfile ]; then
-                  IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+                  IMAGE_ID=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}/$IMAGE_NAME
 
                   IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 


### PR DESCRIPTION
This structure aligns pushing with the expected structure when [pulling](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#installing-a-package).