### PR TITLE
Allow multiuser deployment

### DIFF
--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -34,4 +34,4 @@ RUN url-install https://github.com/ogham/exa/releases/download/v0.9.0/exa-linux-
 RUN url-install https://github.com/XAMPPRocky/tokei/releases/download/v12.0.4/tokei-x86_64-unknown-linux-gnu.tar.gz
 
 COPY .gitconfig /root
-
+CMD [ "source /root/.zshrc", "zsh"]

--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -37,3 +37,5 @@ COPY .gitconfig /root
 
 RUN cp /root/.zshrc /etc/zsh/zshrc
 
+CMD /bin/zsh
+

--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -35,5 +35,5 @@ RUN url-install https://github.com/XAMPPRocky/tokei/releases/download/v12.0.4/to
 
 COPY .gitconfig /root
 
-RUN chmod a+rx /root/.zshrc
-CMD [ "source /root/.zshrc", "zsh"]
+RUN cp /root/.zshrc /etc/zsh/zshrc
+

--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -34,4 +34,6 @@ RUN url-install https://github.com/ogham/exa/releases/download/v0.9.0/exa-linux-
 RUN url-install https://github.com/XAMPPRocky/tokei/releases/download/v12.0.4/tokei-x86_64-unknown-linux-gnu.tar.gz
 
 COPY .gitconfig /root
+
+RUN chmod a+rx /root/.zshrc
 CMD [ "source /root/.zshrc", "zsh"]

--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -18,6 +18,8 @@ RUN apt install --assume-yes --fix-broken \
 
 RUN locale-gen en_US.UTF-8
 
+RUN chmod a+rx /root
+
 RUN bash -c "$(curl -fsSL https://raw.githubusercontent.com/mihaigalos/utils/master/setmeup/setup_oh_my_zsh.sh)"
 RUN bash -c "$(curl -fsSL https://raw.githubusercontent.com/mihaigalos/utils/master/setmeup/setup_vim.sh)"
 


### PR DESCRIPTION
With this PR, users will be able to keep their identity inside the docker container, or opt out.

Keep identity (shell ends with `»`):
```zsh
~ » docker run -it -v "$HOME:$HOME" -v "$HOME/.ssh:$HOME/.ssh:ro" -v "$HOME/.netrc:$HOME/.netrc:ro" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro --user $UID:$UID --env "$USER=$USER" docker.pkg.github.com/mihaigalos/docker/base-ubuntu-20.04:merge /bin/zsh

/ » 
```

Opt-out, default to root (shell ends with `#`):
```zsh
~ » docker run -it docker.pkg.github.com/mihaigalos/docker/base-ubuntu-20.04:merge /bin/zsh

/ #
```