### PR TITLE
Symlink .gitconfig from /root if not exists

### DIFF
--- a/base-ubuntu-20.04/Dockerfile
+++ b/base-ubuntu-20.04/Dockerfile
@@ -36,6 +36,7 @@ RUN url-install https://github.com/XAMPPRocky/tokei/releases/download/v12.0.4/to
 COPY .gitconfig /root
 
 RUN cp /root/.zshrc /etc/zsh/zshrc
+RUN echo '[ ! -f "/home/$USER/.gitconfig" ] && ln -s /root/.gitconfig /home/$USER/' >> /etc/zsh/zshrc
 
 CMD /bin/zsh
 


### PR DESCRIPTION
Example invocation:

```bash
docker run -it -v "$(mktemp -d):$HOME" -v "$(mktemp):$HOME/.zshrc" -v "$HOME/.ssh:$HOME/.ssh:ro" -v "$HOME/.netrc:$HOME/.netrc:ro" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro --user $UID:$UID --env "USER=$USER" docker.pkg.github.com/mihaigalos/docker/base-ubuntu-20.04:merge /bin/zsh
```

The 1st `$(mktemp -d):$HOME` is necessary, because otherwise /home/$USER is automatically created by `root` and the the symlink needs elevated privileges and would fail.

The 2nd `$(mktemp):$HOME/.zshrc` is necessary, because otherwise `zsh` would prompt for initial configuration. Having an empty `.zshrc` circumvents this and uses the default config from `/root/.zshrc` which had been copied to `/etc/zsh/zshrc` in the Dockerfile.  