### PR TITLE
Fix mixing in buildkit and arm64

### DIFF
--- a/.github/workflows/build_and_push.sh
+++ b/.github/workflows/build_and_push.sh
@@ -1,7 +1,14 @@
 #! /bin/bash
 
+set -eoux
+
 function build() {
-    time DOCKER_BUILDKIT=1 docker build . --file Dockerfile$DOCKERFILE_SUFFIX ${PLATFORM} --tag $IMAGE_NAME
+    if [ -z "${DOCKERFILE_SUFFIX}" ]; then
+        time DOCKER_BUILDKIT=1 docker build . --file Dockerfile$DOCKERFILE_SUFFIX ${PLATFORM} --tag $IMAGE_NAME
+    else 
+        # Buildkit cannot cross-build for i.e. arm64
+        time docker build . --file Dockerfile$DOCKERFILE_SUFFIX ${PLATFORM} --tag $IMAGE_NAME
+    fi
 }
 
 function set_variables() {


### PR DESCRIPTION
Enabling buildkit broke arm64 builds. This PR aims at resolving that.